### PR TITLE
enhance finder with caching, default ignore patterns, and improved documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,12 @@
 # Changelog
-# v1.4.0
-- add pre-commit checks for quality improvement
-- add a "test" dependency group and move pytest there
-- revoke more python versions (now >= 3.10) due to use of PEP604 annotation syntax
-# v1.3.0
-- don't use pnpm by default, esp for testing when not available
-# v1.2.0
-- drop support for Python versions that contemporary Django no longer support
-- add pnpm support
-# v1.1.3
-- Fix get_files to return relative paths
-# v1.0.1
-- Convert build to use poetry
-- Use pathlib with glob matching instead of fnmatch for more flexibility
-# v1.0.0
-- Improve speed, separate `npm install` from the finder
-# v0.1.4
-- Fix bug with `NPM_EXECUTABLE_PATH` (thanks @yohanboniface)
-# v0.1.3
-- Actually fix destination bug
-# v0.1.2
-- Fix bug with destination prefix
-# v0.1.1
-- manage.py runserver bugfix
-# v0.1.0
-- Add `NPM_FILE_PATTERNS` setting
-# v0.0.1
-- initial release
+# v1.0.0 - 2024-07-16
+- Forked from the [original repo](https://github.com/kevin1024/django-npm)
+- Added a comprehensive list of default ignore patterns for npm files.
+- Introduced type annotations and docstrings for better code clarity and maintainability.
+- Implemented caching for the get_npm_root_path function.
+- Refactored get_package_patterns to dynamically fetch dependencies from package.json.
+- Updated get_files function to use default ignore patterns.
+- Improved NpmFinder class to use default ignore patterns and autoconfigure match patterns from package.json.
+- Updated README.md with detailed installation and configuration instructions.
+- Simplified and cleaned up tests in test_finder.py.
+- Removed outdated CONTRIBUTING.md file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-Run tests with
-
-`$ pytest`

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Kevin McCarthy
+Copyright (c) 2019 Kevin McCarthy, 2024 David Nugent
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,61 +1,118 @@
 # django-npm-finder
 
-Want to use npm modules in your django project without vendoring them? django-npm serves as a wrapper around the npm/yarn/pnpm cli and provides a staticfiles
-finder that provides integration of your installed node_modules during development and hooks to provide selectively `collectstatic` functionality for production.
+Want to use npm modules in your django project without vendoring them?
+`django-npm-finder` serves as a wrapper around the npm/yarn/pnpm cli and provides a staticfiles
+finder that provides integration of your installed node_modules during development and hooks to
+selectively provide `collectstatic` functionality to export static files for production without
+exposing the entire node_modules hierarchy.
 
-`django-npm-finder` is a fork of kevin1024's [django-npm](https://github.com/keven1024/django-npm) module with modern packaging, dding caching and options to use npm, yarn or pnpm.
-Extensive tests were added with pytest support.
+`django-npm-finder` is a fork of kevin1024's [django-npm](https://github.com/keven1024/django-npm) module with the
+following changes:
+
+- modern `pyproject.toml` packaging (poetry)
+- caching of searches to provide better performance
+- much of the core refactored to be more robust and predictable
+- added support for alternative node managers, such as yarn and pnpm.
+- autoconfigure default match patterns from `package.json` dependencies
+- added an extensive list of default ignore patterns
+- unit tests were added (pytest)
+
+These changes make the module easier to use, more reliable and as autoconfiguring as possible.
 
 ## Installation
 
-1. `$ pip install django-npm-finder`
+- Install into your django project
 
-3. Install npm, yarn or pnpm.
-If you use a private registry, make sure your `.npmrc` or equivalent is set up to connect to it
+```
+  $ pip install django-npm-finder
+```
 
-4. Have a `package.json` at the root of your project, listing your dependencies
+```
+  $ poetry add django-npm-finder
+```
 
-5. Add `django_npm.finders.NpmFinder` to `STATICFILES_FINDERS`
+```
+  $ uv pip install django-npm-finder
+```
 
-6. Configure your `settings.py` as detailed in the following section [Configuration](#configuration)
+- Install npm, yarn or pnpm.
+  If you use a private registry, make sure your `.npmrc` or equivalent is set up to connect to it.
 
-7. `$ ./manage.py npm_install` from the command line, or with your own Python code (see npm install section below).
 
-7. `$ ./manage.py collectstatic` will copy all selected node_modules files into your `STATIC_ROOT`.
-This is only required at deployment, and if using Django runserver for development, will not be required.
+- Have a `package.json` at the root of your project (can be configured), listing your dependencies.
+
+
+- Add `django_npm.finders.NpmFinder` to `STATICFILES_FINDERS`
+
+
+- Configure your `settings.py` as detailed in the following section [Configuration](#configuration)
+
+
+- Run `$ ./manage.py npm_install` from the command line, or with your own Python code
+(see npm install section below).
+Or install your npm modules using `[p]npm|yarn install` from the command line.
+
+
+- `$ ./manage.py collectstatic` will copy all selected node_modules files into your `STATIC_ROOT`.
+   This is only required at deployment, and if using Django runserver for development, will not be required.
 
 ## Configuration
+
 In the following section, reference to `npm` also includes `yarn` or `pnpm`.
 
- * `NPM_ROOT_PATH`: *absolute* path to the npm  "root" directory - this is where npm will look for your `package.json`, put your `node_modules` folder and look for a `.npmrc` file
+* `NPM_ROOT_PATH`: path to the npm "root" directory, where your package manager will look
+  for `package.json`, `node_modules`, `.npmrc` etc.
+  Set this if it differs from the root of your Django project
+  (usually `settings.BASE_DIR` in most Django projects).
 
- * `NPM_EXECUTABLE_PATH`: (optional, default manager) sets `npm` as modules manager and optinoally overrides its location.
-   Supported NPM managers are: npm, yarn and pnpm. If the executable is on the $PATH, the value does not need to contain a full/absolute path.
 
- * `NPM_STATIC_FILES_PREFIX`: (optional) Your npm files will end up under this path inside static, usually something like ` os.path.join('js', 'lib')` (so your files will be in /static/js/lib/react.js for example) but you can leave it blank and they will just end up in the root.
+* `NPM_EXECUTABLE_PATH`: (optional, default manager) sets `npm` as modules manager and optionally
+  overrides its location.
+  Supported NPM managers are: npm, yarn and pnpm.
 
- * `NPM_FILE_PATTERNS`: (optional) By default, django-npm will expose all files in `node_modules` to Django as staticfiles.  You may not want *all* of them to be exposed.  You can pick specific files by adding some additional configuration:
+
+* `NPM_STATIC_FILES_PREFIX`: (optional) Your npm files will be located under this path inside the
+  static URL.
+  As an example, if set to 'vendor' the collected files will be located in
+  `/static/vendor/dist/bootstrap.min.js`, and if not set, it will be located in
+  `/static/dist/bootstrap.min.js`.
+
+
+* `NPM_FILE_PATTERNS`: (optional) By default, django-npm will expose all modules defined as dependencies
+  in `package.json` to Django as staticfiles, excluding files using the default or specified ignore patterns.
+  You may want to restrict what is exposed.
+  You can pick specific files by adding some additional configuration shown in the following code block.
+  Keys are the names of the npm modules, and values are lists containing strings. The strings match against glob patterns.
+  Use double asterisk wildcard '**' to include all subdirectories.
+  > **NOTE**: If unset, the module will autoconfigure modules based on the
+  > dependencies specified in `package.json`.
 ```python
 NPM_FILE_PATTERNS = {
-   'bootstrap': ['dist/**'],
-   'htmx.org': ['htmx.org/dist/**']
+    'bootstrap': ['dist/*'],
+    'htmx.org': ['htmx.org/dist/*']
 }
 ```
-   Keys are the names of the npm modules, and values are lists containing strings.  The strings match against glob patterns.
-   Use '**' to include all subdirectories.
 
- * `NPM_IGNORE_PATTERNS`: (optional) This is a list of patterns to exclude. By default, only files starting with a period '`.`' are excluded.
+* `NPM_IGNORE_PATTERNS`: (optional) This is a python list of patterns to exclude.
+  There is an extensive list of default patterns that are excluded, but you can override this.
 
- * `NPM_FINDER_USE_CACHE`: (default True) A boolean that enables cache in the finder. If enabled, the file list will be computed only once, when the server is started.
+
+* `NPM_FINDER_USE_CACHE`: (default True) A boolean that enables cache in the finder.
+  If enabled, the file list will be computed only once when the server is started.
+
 
 ## npm install
 
-To add the `./manage.py npm_install` command (which runs npm, yarn or pnpm - depending on which node manager is configured in settings)
-"django_npm" must be added to `INSTALLED_APPS`, otherwise it can be omitted.
+To add the `./manage.py npm_install` "django_npm" must be added to Django's `INSTALLED_APPS` setting, otherwise it doesn't need to be added there.
 
-If you want to run `npm install` programmatically, you can do:
+Even if the module is not added in `INSTALLED_APPS` you can run `npm install` programmatically
+from python by creating a script as follows:
 
 ```python
 from django_npm.finders import npm_install
+
 npm_install()
 ```
+
+The advantage of using `npm_install` is that it will run the package manager configured in
+your Django settings.

--- a/django_npm/finders.py
+++ b/django_npm/finders.py
@@ -134,8 +134,9 @@ def get_package_patterns(node_modules_root: Union[str, Path]) -> Dict[str, List[
     """
     package_json = Path(node_modules_root) / "package.json"
     packages = {"*": ["*"]}
-    with contextlib.suppress(IOError):
-        with contextlib.suppress(json.JSONDecodeError):
+    with contextlib.suppress(IOError, json.JSONDecodeError):
+        with package_json.open() as f:
+            pkg_json = json.load(f)
             with package_json.open() as f:
                 pkg_json = json.load(f)
                 if "dependencies" in pkg_json:

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -52,7 +52,7 @@ def storage(npm_dir):
 def test_get_files_all(storage):
     files = list(get_files(storage, match_patterns=["*"]))
     assert len(files)
-    assert all(filename for filename in files)
+    assert all(files)
 
 
 def test_get_files_with_patterns(storage):
@@ -76,7 +76,7 @@ def test_finder_list_all(npm_dir):
     assert len(results)
     assert all(isinstance(result, tuple) for result in results)
     assert all(path for path, storage in results)
-    assert all(storage is not None for filename, storage in results)
+    assert all(store is not None for filename, store in results)
 
 
 def test_finder_list_in_module(npm_dir):
@@ -87,7 +87,7 @@ def test_finder_list_in_module(npm_dir):
         assert len(results)
         assert all(isinstance(result, tuple) for result in results)
         assert all(path for path, storage in results)
-        assert all(storage is not None for filename, storage in results)
+        assert all(store is not None for filename, store in results)
 
 
 def test_finder_list_files_in_module(npm_dir):
@@ -104,7 +104,7 @@ def test_finder_list_files_in_module(npm_dir):
         assert len(results)
         assert all(isinstance(result, tuple) for result in results)
         assert all(path for path, storage in results)
-        assert all(storage is not None for filename, storage in results)
+        assert all(store is not None for filename, store in results)
 
 
 def test_finder_find(npm_dir):
@@ -136,7 +136,7 @@ def test_finder_with_patterns_in_directory_component(npm_dir):
         NPM_STATIC_FILES_PREFIX="lib", NPM_FILE_PATTERNS={"mocha": ["*.js"]}
     ):
         f = NpmFinder()
-        file = f.find("lib/mocha/lib/test.js")
+        file = f.find("lib/mocha/lib/mocha.js")
         assert file
 
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the django-npm-finder by adding default ignore patterns, implementing caching for the get_npm_root_path function, and dynamically fetching dependencies from package.json. It also includes significant documentation updates and test improvements.

- **New Features**:
    - Introduced default ignore patterns for npm files to streamline file exclusion.
    - Implemented caching for the get_npm_root_path function to improve performance.
    - Added dynamic fetching of dependencies from package.json in get_package_patterns function.
- **Enhancements**:
    - Refactored get_setting function to include type annotations and docstrings for better code clarity.
    - Updated get_files function to use default ignore patterns if none are provided.
    - Improved NpmFinder class to use default ignore patterns and autoconfigure match patterns from package.json.
- **Documentation**:
    - Updated README.md with detailed installation and configuration instructions.
    - Removed outdated CONTRIBUTING.md file.
- **Tests**:
    - Simplified and cleaned up tests in test_finder.py to ensure better readability and maintainability.

<!-- Generated by sourcery-ai[bot]: end summary -->