### PR TITLE
Fix django 5.2 issue around find_all key word.

### DIFF
--- a/django_npm/finders.py
+++ b/django_npm/finders.py
@@ -246,7 +246,7 @@ class NpmFinder(FileSystemFinder):
         self.cached_list = None
 
     # noinspection PyShadowingBuiltins
-    def find(self, path, all=False):
+    def find(self, path, all=False, find_all=False):
         relpath = os.path.relpath(path, self.destination)
         for prefix, root in self.locations:
             storage = self.storages[root]


### PR DESCRIPTION
All django to pass in find_all as a key work.

The variable is unused anyway, so just define a keyword to allow code to work.

## Summary by Sourcery

Bug Fixes:
- Modify the find method signature to support find_all keyword to ensure compatibility with Django 5.2