### PR TITLE
Add agent project context documents

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13", "3.12", "3.11"]
+        python-version: ["3.14", "3.13", "3.12", "3.11"]
 
     steps:
       - name: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.13", "3.12", "3.11"]
+        python-version: ["3.14", "3.13", "3.12", "3.11"]
 
     steps:
       - name: checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+---
+type: agent/information
+description: Minimal instructions for agents working in this repository.
+---
+
+# Agents
+
+Read [project.md](./project.md) first for repository purpose, history, and working context.
+
+Keep changes small, library-safe, and backward-compatible unless the task explicitly requires otherwise.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,6 @@ description: Minimal instructions for agents working in this repository.
 
 # Agents
 
-Read [project.md](./project.md) first for repository purpose, history, and working context.
+Read [project.md](./project.md) first for the repository's purpose, history, and working context.
 
 Keep changes small, library-safe, and backward-compatible unless the task explicitly requires otherwise.

--- a/project.md
+++ b/project.md
@@ -1,0 +1,24 @@
+---
+type: agent/information
+description: Brief project context for agents working in this repository.
+---
+
+# Project
+
+`django-npm-finder` is a Python package for Django projects that exposes selected assets from `node_modules` through Django staticfiles and supports collecting those assets for deployment. It is intended to avoid vendoring frontend packages directly into a Django codebase while still keeping static asset handling predictable.
+
+## History
+
+This repository is a fork of the earlier `django-npm` project. The fork modernized packaging and development tooling, added support for multiple Node package managers (`npm`, `yarn`, `pnpm`), improved finder behavior and caching, and expanded test coverage.
+
+## Agent Context
+
+Treat this as a small library project rather than an application. Prefer changes that preserve backward compatibility, keep configuration explicit, and avoid widening the public API without a clear need.
+
+Primary stack and tooling:
+- Python package managed with `uv`
+- Django dependency and integration surface
+- `pytest` for tests
+- `ruff` for linting
+
+When getting oriented, start with `README.md`, `pyproject.toml`, and the `django_npm/` package.


### PR DESCRIPTION
## Summary
Add lightweight agent-oriented repository context documents.

## Changes
- add `project.md` with purpose, fork history, and brief onboarding context for agents
- add `AGENTS.md` that directs agents to `project.md`

## Notes
These documents are intentionally short to keep agent context small.

## Summary by Sourcery

Add lightweight agent-focused project context documents to guide automated agents working in this repository.

Documentation:
- Introduce project.md with high-level project purpose, history, technology stack, and orientation guidance for agents.
- Add AGENTS.md with minimal instructions directing agents to project context and expected change philosophy.