### PR TITLE
Fix nested package collection during collectstatic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Upgraded project dependencies to the latest compatible versions.
 - Fixed caching in `get_files()` so repeated lookups reuse cached filesystem traversal state across calls.
-- Pending: analyse and fix potential bug #2.
+- Fixed recursive package matching so `collectstatic` includes nested files for default dependency patterns, including scoped packages such as `@fortawesome/fontawesome-free`.
 
 ## v1.2.0 - 2025-04-21
 

--- a/django_npm/finders.py
+++ b/django_npm/finders.py
@@ -94,6 +94,48 @@ def _ignorelist(ignore_patterns: tuple[str, ...]) -> tuple[tuple[str, str], ...]
     return tuple(splitpath(patt) for patt in ignore_patterns)
 
 
+def _matches_pattern(
+    relpath_posix: str,
+    reldir: str,
+    relname: str,
+    pattern: str,
+    patternpath: str,
+    patternname: str,
+) -> bool:
+    # Preserve the original filename/directory semantics for normal globs, but
+    # treat terminal "/**" as "everything under this directory recursively".
+    if pattern.endswith("/**"):
+        prefix = pattern[:-3].rstrip("/")
+        return relpath_posix.startswith(f"{prefix}/") if prefix else True
+    if "/**/" in pattern:
+        prefix, suffix = pattern.split("/**/", maxsplit=1)
+        if prefix and not relpath_posix.startswith(f"{prefix}/"):
+            return False
+        remainder = relpath_posix[len(prefix) + 1 :] if prefix else relpath_posix
+        candidates = [remainder]
+        segments = remainder.split("/")
+        for index in range(1, len(segments)):
+            candidates.append("/".join(segments[index:]))
+        return any(fnmatch.fnmatch(candidate, suffix) for candidate in candidates)
+    return fnmatch.fnmatch(relname, patternname) and (
+        not patternpath or fnmatch.fnmatch(reldir, patternpath)
+    )
+
+
+def _matches_find_pattern(
+    relpath_posix: str,
+    relname: str,
+    pattern: str,
+    patternname: str,
+) -> bool:
+    # Preserve the historical find() behavior: configured patterns constrain the
+    # filename, while terminal "/**" remains recursive for package defaults.
+    if pattern.endswith("/**"):
+        prefix = pattern[:-3].rstrip("/")
+        return relpath_posix.startswith(f"{prefix}/") if prefix else True
+    return fnmatch.fnmatch(relname, patternname)
+
+
 def _ignored(relpath: Path, ignore_patterns: tuple[str, ...]) -> bool:
     reldir, relname = splitpath(relpath)
     return any(
@@ -127,18 +169,12 @@ def _rglob(
             relpath_posix = relpath.as_posix()
             reldir, relname = splitpath(relpath)
             if not find_pattern:
-                # Preserve filename-only matching for patterns like "*.js", but use the
-                # full relative path for path-aware patterns such as "pkg/**".
-                if "/" in pattern or "**" in pattern:
-                    matches = fnmatch.fnmatch(relpath_posix, pattern)
-                else:
-                    matches = fnmatch.fnmatch(relname, patternname) and (
-                        not patternpath or fnmatch.fnmatch(reldir, patternpath)
-                    )
-                if matches:
+                if _matches_pattern(
+                    relpath_posix, reldir, relname, pattern, patternpath, patternname
+                ):
                     results.append(relpath)
             elif (
-                fnmatch.fnmatch(relpath_posix, pattern)
+                _matches_find_pattern(relpath_posix, relname, pattern, patternname)
                 and (not findpath or reldir == findpath)
                 and fnmatch.fnmatch(relname, findname)
             ):
@@ -241,7 +277,7 @@ def get_files(
 
     root = Path(storage.base_location).resolve()
 
-    if not ignore_patterns:
+    if ignore_patterns is None:
         ignore_patterns = DEFAULT_IGNORE_PATTERNS
 
     ignore_patterns = tuple(ignore_patterns)

--- a/django_npm/finders.py
+++ b/django_npm/finders.py
@@ -124,13 +124,17 @@ def _rglob(
             )
         elif path.is_file():
             reldir, relname = splitpath(relpath)
-            if fnmatch.fnmatch(relname, patternname):
-                if not find_pattern:
-                    if not patternpath or fnmatch.fnmatch(reldir, patternpath):
-                        results.append(relpath)
-                elif not findpath or reldir == findpath:
-                    if fnmatch.fnmatch(relname, findname):
-                        results.append(relpath)
+            if not find_pattern:
+                # For list/collectstatic behavior, match against the full relative path so
+                # patterns like "pkg/**" include nested files, not just top-level ones.
+                if fnmatch.fnmatch(relpath.as_posix(), glob_pattern or "*"):
+                    results.append(relpath)
+            elif (
+                fnmatch.fnmatch(relpath.as_posix(), glob_pattern or "*")
+                and (not findpath or reldir == findpath)
+                and fnmatch.fnmatch(relname, findname)
+            ):
+                results.append(relpath)
     return tuple(results)
 
 

--- a/django_npm/finders.py
+++ b/django_npm/finders.py
@@ -112,7 +112,8 @@ def _rglob(
     ignore_patterns: tuple[str, ...],
 ) -> tuple[Path, ...]:
     results = []
-    patternpath, patternname = splitpath(glob_pattern or "*")
+    pattern = glob_pattern or "*"
+    patternpath, patternname = splitpath(pattern)
     findpath, findname = splitpath(find_pattern)
     for path in topdir.iterdir():
         relpath = path.relative_to(root)
@@ -123,14 +124,21 @@ def _rglob(
                 _rglob(root, path, glob_pattern or "*", find_pattern, ignore_patterns)
             )
         elif path.is_file():
+            relpath_posix = relpath.as_posix()
             reldir, relname = splitpath(relpath)
             if not find_pattern:
-                # For list/collectstatic behavior, match against the full relative path so
-                # patterns like "pkg/**" include nested files, not just top-level ones.
-                if fnmatch.fnmatch(relpath.as_posix(), glob_pattern or "*"):
+                # Preserve filename-only matching for patterns like "*.js", but use the
+                # full relative path for path-aware patterns such as "pkg/**".
+                if "/" in pattern or "**" in pattern:
+                    matches = fnmatch.fnmatch(relpath_posix, pattern)
+                else:
+                    matches = fnmatch.fnmatch(relname, patternname) and (
+                        not patternpath or fnmatch.fnmatch(reldir, patternpath)
+                    )
+                if matches:
                     results.append(relpath)
             elif (
-                fnmatch.fnmatch(relpath.as_posix(), glob_pattern or "*")
+                fnmatch.fnmatch(relpath_posix, pattern)
                 and (not findpath or reldir == findpath)
                 and fnmatch.fnmatch(relname, findname)
             ):

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -77,6 +77,13 @@ def test_get_files_with_patterns(storage):
     assert files != files_all
 
 
+def test_get_files_filename_only_pattern_matches_nested_files(storage):
+    files = list(get_files(storage, match_patterns=["*.js"]))
+    assert len(files)
+    assert any(path.as_posix() == "mocha/index.js" for path in files)
+    assert any("lib/mocha.js" in path.as_posix() for path in files)
+
+
 def test_splitpath_normalizes_windows_separators():
     assert splitpath("mocha\\*.js") == ("mocha", "*.js")
     assert splitpath("mocha\\") == ("mocha", "*")

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -89,6 +89,12 @@ def test_flatten_patterns_uses_posix_paths():
     ]
 
 
+def test_flatten_patterns_scoped_package_uses_recursive_match():
+    assert flatten_patterns({"@fortawesome/fontawesome-free": ["**"]}) == [
+        "@fortawesome/fontawesome-free/**"
+    ]
+
+
 def test_get_files_reuses_cached_directory_walk(storage, monkeypatch):
     calls = Counter()
     original_iterdir = Path.iterdir
@@ -110,6 +116,30 @@ def test_get_files_reuses_cached_directory_walk(storage, monkeypatch):
     assert first == second
     assert first_counts
     assert dict(calls) == first_counts
+
+
+def test_get_files_scoped_package_recursive_pattern(tmp_path):
+    package_root = tmp_path / "node_modules" / "@fortawesome" / "fontawesome-free"
+    (package_root / "css").mkdir(parents=True)
+    (package_root / "js").mkdir(parents=True)
+    (package_root / "attribution.js").write_text("")
+    (package_root / "css" / "all.css").write_text("")
+    (package_root / "js" / "all.js").write_text("")
+    storage = FileSystemStorage(location=str(tmp_path / "node_modules"))
+
+    files = list(
+        get_files(
+            storage,
+            match_patterns=["@fortawesome/fontawesome-free/**"],
+            ignore_patterns=[],
+        )
+    )
+    assert any(
+        path.as_posix() == "@fortawesome/fontawesome-free/attribution.js"
+        for path in files
+    )
+    assert any("css/all.css" in path.as_posix() for path in files)
+    assert any("js/all.js" in path.as_posix() for path in files)
 
 
 def test_finder_list_all(npm_dir):

--- a/tests/test_finder.py
+++ b/tests/test_finder.py
@@ -63,6 +63,17 @@ def test_get_files_all(storage):
     assert all(files)
 
 
+def test_get_files_empty_ignore_patterns_disables_default_ignores(tmp_path):
+    node_modules = tmp_path / "node_modules" / "pkg"
+    node_modules.mkdir(parents=True)
+    (node_modules / "README.md").write_text("")
+    storage = FileSystemStorage(location=str(tmp_path / "node_modules"))
+
+    files = list(get_files(storage, match_patterns=["pkg/*"], ignore_patterns=[]))
+
+    assert [path.as_posix() for path in files] == ["pkg/README.md"]
+
+
 def test_get_files_with_patterns(storage):
     files_all = list(get_files(storage, match_patterns=["*.js", "*.css"]))
     assert len(files_all)
@@ -147,6 +158,50 @@ def test_get_files_scoped_package_recursive_pattern(tmp_path):
     )
     assert any("css/all.css" in path.as_posix() for path in files)
     assert any("js/all.js" in path.as_posix() for path in files)
+
+
+def test_get_files_non_recursive_path_pattern_does_not_match_nested_files(tmp_path):
+    package_root = tmp_path / "node_modules" / "bootstrap" / "dist"
+    (package_root / "js").mkdir(parents=True)
+    (package_root / "bootstrap.min.js").write_text("")
+    (package_root / "js" / "bootstrap.min.js").write_text("")
+    storage = FileSystemStorage(location=str(tmp_path / "node_modules"))
+
+    files = list(
+        get_files(
+            storage,
+            match_patterns=["bootstrap/dist/*"],
+            ignore_patterns=[],
+        )
+    )
+
+    assert [path.as_posix() for path in files] == ["bootstrap/dist/bootstrap.min.js"]
+
+
+def test_get_files_recursive_subdirectory_pattern_matches_nested_files(tmp_path):
+    package_root = tmp_path / "node_modules" / "bootstrap"
+    (package_root / "src").mkdir(parents=True)
+    (package_root / "js" / "src").mkdir(parents=True)
+    (package_root / "deep" / "nested" / "src").mkdir(parents=True)
+    (package_root / "src" / "root.js").write_text("")
+    (package_root / "js" / "src" / "nested.js").write_text("")
+    (package_root / "deep" / "nested" / "src" / "deep.js").write_text("")
+    (package_root / "deep" / "nested" / "src" / "deep.css").write_text("")
+    storage = FileSystemStorage(location=str(tmp_path / "node_modules"))
+
+    files = list(
+        get_files(
+            storage,
+            match_patterns=["bootstrap/**/src/*.js"],
+            ignore_patterns=[],
+        )
+    )
+
+    assert sorted(path.as_posix() for path in files) == [
+        "bootstrap/deep/nested/src/deep.js",
+        "bootstrap/js/src/nested.js",
+        "bootstrap/src/root.js",
+    ]
 
 
 def test_finder_list_all(npm_dir):


### PR DESCRIPTION
## Overview
Fix package matching for default dependency patterns so `collectstatic` includes nested files for scoped and non-scoped packages.

## Changes
- match list/collectstatic patterns against the full relative package path
- preserve `find()` filtering against configured package patterns
- add regression tests for recursive scoped-package matching
- update the `v1.3.0` changelog entry for this fix

## Impact
Projects relying on the default dependency-based patterns will now collect nested package assets correctly, including packages such as `@fortawesome/fontawesome-free`.

## Notes
closes #12

## Summary by Sourcery

Fix recursive static file collection for dependency-based package patterns and update documentation accordingly.

Bug Fixes:
- Ensure list and collectstatic match patterns against the full relative package path so nested package files are included for default dependency patterns, including scoped packages.

Documentation:
- Clarify in the v1.3.0 changelog that recursive package matching now includes nested files for default dependency patterns and scoped packages.

Tests:
- Add regression tests verifying recursive pattern flattening and file collection for scoped packages like @fortawesome/fontawesome-free.